### PR TITLE
Suppress /etc/hosts warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - README update [#4](https://github.com/netsec-ethz/scion-java-packet-example/pull/4)
 
+### Fixed
+- Suppress warning when parsing /etc/hosts file with SCION addresses
+  [#6](https://github.com/netsec-ethz/scion-java-packet-example/pull/6)
+
 ## [0.1.3] - 2024-10-09
 
 ### Changed

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,3 +1,4 @@
 org.slf4j.simpleLogger.defaultLogLevel = WARN
 # org.slf4j.simpleLogger.defaultLogLevel = INFO
 # org.slf4j.simpleLogger.defaultLogLevel = DEBUG
+org.slf4j.simpleLogger.log.org.xbill.DNS.hosts.HostsFileParser = ERROR


### PR DESCRIPTION
dnsjava prints a warning when parsing SCION addresses in the `/etc/hosts` file.
See https://github.com/dnsjava/dnsjava/issues/361